### PR TITLE
oc start-build needs '--wait' to prevent timeout if build is pending

### DIFF
--- a/oc.mk
+++ b/oc.mk
@@ -50,7 +50,7 @@ endef
 
 define oc_build
 	@@echo ✓ building $(1)
-	@@$(OC) -n $(OC_PROJECT) start-build $(1) --follow
+	@@$(OC) -n $(OC_PROJECT) start-build $(1) --wait --follow
 	@@echo ✓ tagging $(1):$(GIT_SHA1) to $(1):$(GIT_BRANCH_NORM)
 	@@$(OC) -n $(OC_PROJECT) tag $(1):$(GIT_SHA1) $(1):$(GIT_BRANCH_NORM)
 endef


### PR DESCRIPTION
If another build is running, or the new pod takes a long time to start for whatever reason, `oc start-build --follow` will timeout, and output the following:

```
Failed to stream the build logs - to view the logs, run oc logs build/your-build-instance
Error: unable to stream the build logs; caused by: unable to wait for build your-build-instance to run: timed out waiting for the condition
```

Adding the `--wait` option fixes that issue. This was tested ad-hoc with a new build that had to wait several minutes before starting.