### PR TITLE
Support parallel and incremental builds

### DIFF
--- a/git.mk
+++ b/git.mk
@@ -2,7 +2,6 @@ GIT=$(shell command -v git)
 GIT_SHA1=$(shell echo "$${CIRCLE_SHA1:-`$(GIT) rev-parse HEAD`}")
 GIT_BRANCH=$(strip $(shell $(GIT) rev-parse --abbrev-ref HEAD))
 GIT_BRANCH_NORM=$(subst /,-,$(GIT_BRANCH)) # openshift doesn't like slashes
-GIT_ORIGIN_URL=$(shell git config --get remote.origin.url)
 
 ifeq ($(GIT),)
 	$(error 'git' not found in $$PATH)

--- a/git.mk
+++ b/git.mk
@@ -1,7 +1,8 @@
 GIT=$(shell command -v git)
 GIT_SHA1=$(shell echo "$${CIRCLE_SHA1:-`$(GIT) rev-parse HEAD`}")
 GIT_BRANCH=$(strip $(shell $(GIT) rev-parse --abbrev-ref HEAD))
-GIT_BRANCH_NORM=$(subst /,-,$(GIT_BRANCH)) # openshift doesn't like slashes 
+GIT_BRANCH_NORM=$(subst /,-,$(GIT_BRANCH)) # openshift doesn't like slashes
+GIT_ORIGIN_URL=$(shell git config --get remote.origin.url)
 
 ifeq ($(GIT),)
 	$(error 'git' not found in $$PATH)

--- a/jq.mk
+++ b/jq.mk
@@ -1,0 +1,6 @@
+JQ := $(shell command -v jq)
+
+ifeq ($(JQ),)
+	$(error 'jq' not found in $$PATH)
+endif
+

--- a/lib/oc_build.sh
+++ b/lib/oc_build.sh
@@ -9,7 +9,7 @@ GIT_SHA1=$5
 echo "✓ building $BUILD_CONFIG"
 $OC -n $OC_PROJECT start-build $BUILD_CONFIG --follow
 
-if [ "`$OC -n $OC_PROJECT get is/$BUILD_CONFIG -o=go-template='{{range .status.tags}}{{if eq .tag "$GIT_SHA1"}}{{"true"}}{{end}}{{end}}'`" == "true" ]; then
+if [ "`$OC -n $OC_PROJECT get is/$BUILD_CONFIG -o=go-template='{{range .status.tags}}{{if eq .tag "'$GIT_SHA1'"}}{{"true"}}{{end}}{{end}}'`" == "true" ]; then
     echo "✓ tagging $BUILD_CONFIG:$GIT_SHA1 to $BUILD_CONFIG:$GIT_BRANCH_NORM"
     $OC -n $OC_PROJECT tag $BUILD_CONFIG:$GIT_SHA1 $BUILD_CONFIG:$GIT_BRANCH_NORM
 else

--- a/lib/oc_build.sh
+++ b/lib/oc_build.sh
@@ -7,7 +7,6 @@ GIT_BRANCH_NORM=$4
 GIT_SHA1=$5
 OC_TEMPLATE_VARS=$6
 
-
 # Find the build config for this build and run `oc apply` for it
 for FILE in `find openshift/build/buildconfig -name \*.yml -print`; do
     BUILD_CONFIG_STRING=$($OC process --ignore-unknown-parameters=true -f $FILE $OC_TEMPLATE_VARS | jq 'if .items[].metadata.name == "'$BUILD_CONFIG'" then .items[].metadata.labels=(.items[].metadata.labels + { "cas-pipeline/commit.id":"'$GIT_SHA1'" }) else empty end')
@@ -17,41 +16,32 @@ for FILE in `find openshift/build/buildconfig -name \*.yml -print`; do
 done
 
 echo "✓ building $BUILD_CONFIG"
-$OC -n $OC_PROJECT start-build $BUILD_CONFIG --follow
+BUILD_OBJECT=$($OC -n $OC_PROJECT start-build $BUILD_CONFIG --output=name)
 
-if [ "`$OC -n $OC_PROJECT get is/$BUILD_CONFIG -o=go-template='{{range .status.tags}}{{if eq .tag "'$GIT_SHA1'"}}{{"true"}}{{end}}{{end}}'`" == "true" ]; then
-    echo "✓ tagging $BUILD_CONFIG:$GIT_SHA1 to $BUILD_CONFIG:$GIT_BRANCH_NORM"
-    $OC -n $OC_PROJECT tag $BUILD_CONFIG:$GIT_SHA1 $BUILD_CONFIG:$GIT_BRANCH_NORM
-else
-    # Go through the last builds to find which image corresponds to the build config
-    BUILD_VERSION=`$OC -n $OC_PROJECT get bc/$BUILD_CONFIG -o=go-template='{{.status.lastVersion}}'`
-    while [ -z "$IMAGE_ID" ]; do
-        IMAGE_ID=`$OC -n $OC_PROJECT get build/$BUILD_CONFIG-$BUILD_VERSION -o=go-template='{{if (index .metadata.labels "cas-pipeline/commit.id")}}{{if eq (index .metadata.labels "cas-pipeline/commit.id") "'$GIT_SHA1'"}}{{.status.output.to.imageDigest}}{{end}}{{end}}'`
-        if [[ ! $? -eq 0 ]]; then
-            # The oc command returned an error. Likely because we are trying to get a build that does not exist anymore
-            exit 1
-        fi
-        BUILD_VERSION=$[$BUILD_VERSION - 1]
-    done
-    if [[ $IMAGE_ID == sha256* ]]; then
-        echo "✓ tagging $BUILD_CONFIG@$IMAGE_ID to $BUILD_CONFIG:$GIT_SHA1"
-        RETRIES=5
-        while [ "$RETRIES" -gt 0 ]; do
-            $OC -n $OC_PROJECT tag $BUILD_CONFIG@$IMAGE_ID $BUILD_CONFIG:$GIT_SHA1 > /dev/null 2>&1
-            $OC -n $OC_PROJECT get istag/$BUILD_CONFIG:$GIT_SHA1 > /dev/null 2>&1
-            if [ $? -eq 0 ]; then
-                echo "✓ Image tag $BUILD_CONFIG:$GIT_SHA1 found."
-                exit 0
-            else
-                echo "Retrying..."
-                RETRIES=$[$RETRIES - 1]
-                sleep 5
-            fi
-        done
-        echo "✘ Failed to tag $BUILD_CONFIG@$IMAGE_ID to $BUILD_CONFIG:$GIT_SHA1"
-        exit 1
-    else
-        echo "✘ Image stream $BUILD_CONFIG:$GIT_BRANCH_NORM for commit $GIT_SHA1 was not found."
-        exit 1
-    fi
+get_build_status() {
+    echo $($OC -n $OC_PROJECT get $BUILD_OBJECT -o=go-template='{{.status.phase}}')
+}
+
+echo -n "Waiting for $BUILD_OBJECT to start "
+while [[ $(get_build_status) == "New" || $(get_build_status) == "Pending" ]]; do
+    sleep 5
+    echo -n "."
+done
+echo ""
+
+while [[ $(get_build_status) == "Running" ]]; do
+    # This loop makes the script attempt to read the logs again in case of an unexpected EOF
+    $OC -n $OC_PROJECT logs $BUILD_OBJECT --follow
+    sleep 5
+done
+
+if [ $(get_build_status) != "Complete" ]; then
+    echo "✘ build $BUILD_OBJECT ended with status $(get_build_status)."
+    echo "message: $($OC -n $OC_PROJECT get $BUILD_OBJECT -o=go-template='{{.status.message}}')"
+    exit 1
 fi
+
+IMAGE_ID=$($OC -n $OC_PROJECT get $BUILD_OBJECT -o=go-template='{{.status.output.to.imageDigest}}')
+
+$OC -n $OC_PROJECT tag $BUILD_CONFIG@$IMAGE_ID $BUILD_CONFIG:$GIT_SHA1
+$OC -n $OC_PROJECT tag $BUILD_CONFIG@$IMAGE_ID $BUILD_CONFIG:$GIT_BRANCH_NORM

--- a/lib/oc_build.sh
+++ b/lib/oc_build.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+OC=$1
+OC_PROJECT=$2
+BUILD_CONFIG=$3
+GIT_BRANCH_NORM=$4
+GIT_SHA1=$5
+
+echo "✓ building $BUILD_CONFIG"
+$OC -n $OC_PROJECT start-build $BUILD_CONFIG --follow
+
+if [ "`$OC -n $OC_PROJECT get is/$BUILD_CONFIG -o=go-template='{{range .status.tags}}{{if eq .tag "$GIT_SHA1"}}{{"true"}}{{end}}{{end}}'`" == "true" ]; then
+    echo "✓ tagging $BUILD_CONFIG:$GIT_SHA1 to $BUILD_CONFIG:$GIT_BRANCH_NORM"
+    $OC -n $OC_PROJECT tag $BUILD_CONFIG:$GIT_SHA1 $BUILD_CONFIG:$GIT_BRANCH_NORM
+else
+    # Go through the last builds to find which image corresponds to the build config
+    BUILD_VERSION=`$OC -n $OC_PROJECT get bc/$BUILD_CONFIG -o=go-template='{{.status.lastVersion}}'`
+    while [ -z "$IMAGE_ID" ]; do
+        IMAGE_ID=`$OC -n $OC_PROJECT get build/$BUILD_CONFIG-$BUILD_VERSION -o=go-template='{{if (index .metadata.labels "cas-pipeline/commit.id")}}{{if eq (index .metadata.labels "cas-pipeline/commit.id") "'$GIT_SHA1'"}}{{.status.output.to.imageDigest}}{{end}}{{end}}'`
+        if [[ ! $? -eq 0 ]]; then
+            # The oc command returned an error. Likely because we are trying to get a build that does not exist anymore
+            exit 1
+        fi
+        BUILD_VERSION=$[$BUILD_VERSION - 1]
+    done
+    if [[ $IMAGE_ID == sha256* ]]; then
+        echo "✓ tagging $BUILD_CONFIG@$IMAGE_ID to $BUILD_CONFIG:$GIT_SHA1"
+        RETRIES=5
+        while [ "$RETRIES" -gt 0 ]; do
+            $OC -n $OC_PROJECT tag $BUILD_CONFIG@$IMAGE_ID $BUILD_CONFIG:$GIT_SHA1 > /dev/null 2>&1
+            $OC -n $OC_PROJECT get istag/$BUILD_CONFIG:$GIT_SHA1 > /dev/null 2>&1
+            if [ $? -eq 0 ]; then
+                echo "✓ Image tag $BUILD_CONFIG:$GIT_SHA1 found."
+                exit 0
+            else
+                echo "Retrying..."
+                RETRIES=$[$RETRIES - 1]
+                sleep 5
+            fi
+        done
+        echo "✘ Failed to tag $BUILD_CONFIG@$IMAGE_ID to $BUILD_CONFIG:$GIT_SHA1"
+        exit 1
+    else
+        echo "✘ Image stream $BUILD_CONFIG:$GIT_BRANCH_NORM for commit $GIT_SHA1 was not found."
+        exit 1
+    fi
+fi

--- a/lib/oc_build.sh
+++ b/lib/oc_build.sh
@@ -6,20 +6,22 @@ BUILD_CONFIG=$3
 GIT_BRANCH_NORM=$4
 GIT_SHA1=$5
 OC_TEMPLATE_VARS=$6
+JQ=$7
 
 # Find the build config for this build and run `oc apply` for it
-for FILE in `find openshift/build/buildconfig -name \*.yml -print`; do
-    BUILD_CONFIG_STRING=$($OC process --ignore-unknown-parameters=true -f $FILE $OC_TEMPLATE_VARS | jq 'if .items[].metadata.name == "'$BUILD_CONFIG'" then .items[].metadata.labels=(.items[].metadata.labels + { "cas-pipeline/commit.id":"'$GIT_SHA1'" }) else empty end')
-    if [[ ! -z "$BUILD_CONFIG_STRING" ]]; then
-	    echo $BUILD_CONFIG_STRING | $OC -n "$OC_PROJECT" apply --wait --overwrite --validate -f-
+shopt -s globstar nullglob
+for FILE in openshift/build/buildconfig/**/*.yml; do
+    BUILD_CONFIG_STRING=$("$OC" process --ignore-unknown-parameters=true -f "$FILE" "$OC_TEMPLATE_VARS" | "$JQ" "if .items[].metadata.name == \"$BUILD_CONFIG\" then .items[].metadata.labels=(.items[].metadata.labels + { \"cas-pipeline/commit.id\":\"$GIT_SHA1\" }) else empty end")
+    if [[ -n "$BUILD_CONFIG_STRING" ]]; then
+        echo "$BUILD_CONFIG_STRING" | "$OC" -n "$OC_PROJECT" apply --wait --overwrite --validate -f-
     fi
 done
 
 echo "✓ building $BUILD_CONFIG"
-BUILD_OBJECT=$($OC -n $OC_PROJECT start-build $BUILD_CONFIG --output=name)
+BUILD_OBJECT="$("$OC" -n "$OC_PROJECT" start-build "$BUILD_CONFIG" --output=name)"
 
 get_build_status() {
-    echo $($OC -n $OC_PROJECT get $BUILD_OBJECT -o=go-template='{{.status.phase}}')
+    "$OC" -n "$OC_PROJECT" get "$BUILD_OBJECT" -o=go-template='{{.status.phase}}'
 }
 
 echo -n "Waiting for $BUILD_OBJECT to start "
@@ -31,17 +33,17 @@ echo ""
 
 while [[ $(get_build_status) == "Running" ]]; do
     # This loop makes the script attempt to read the logs again in case of an unexpected EOF
-    $OC -n $OC_PROJECT logs $BUILD_OBJECT --follow
+    "$OC" -n "$OC_PROJECT" logs "$BUILD_OBJECT" --follow
     sleep 5
 done
 
-if [ $(get_build_status) != "Complete" ]; then
+if [[ $(get_build_status) != "Complete" ]]; then
     echo "✘ build $BUILD_OBJECT ended with status $(get_build_status)."
-    echo "message: $($OC -n $OC_PROJECT get $BUILD_OBJECT -o=go-template='{{.status.message}}')"
+    echo "message: $("$OC" -n "$OC_PROJECT" get "$BUILD_OBJECT" -o=go-template='{{.status.message}}')"
     exit 1
 fi
 
-IMAGE_ID=$($OC -n $OC_PROJECT get $BUILD_OBJECT -o=go-template='{{.status.output.to.imageDigest}}')
+IMAGE_ID=$("$OC" -n "$OC_PROJECT" get "$BUILD_OBJECT" -o=go-template='{{.status.output.to.imageDigest}}')
 
-$OC -n $OC_PROJECT tag $BUILD_CONFIG@$IMAGE_ID $BUILD_CONFIG:$GIT_SHA1
-$OC -n $OC_PROJECT tag $BUILD_CONFIG@$IMAGE_ID $BUILD_CONFIG:$GIT_BRANCH_NORM
+"$OC" -n "$OC_PROJECT" tag "$BUILD_CONFIG@$IMAGE_ID" "$BUILD_CONFIG:$GIT_SHA1"
+"$OC" -n "$OC_PROJECT" tag "$BUILD_CONFIG@$IMAGE_ID" "$BUILD_CONFIG:$GIT_BRANCH_NORM"

--- a/oc.mk
+++ b/oc.mk
@@ -52,17 +52,17 @@ define oc_build
 	@@echo ✓ building $(1)
 	@@$(OC) -n $(OC_PROJECT) start-build $(1) --follow
 
-	HAS_SHA1_TAG = @@$(OC) -n $(OC_PROJECT) get is/$(1) -o=go-template='{{range .status.tags}}{{if eq .tag "$(GIT_SHA1)"}}{{"true"}}{{break}}{{end}}{{end}}'
+	@@$(eval HAS_SHA1_TAG = $(shell $(OC) -n $(OC_PROJECT) get is/$(1) -o=go-template='{{range .status.tags}}{{if eq .tag "$(GIT_SHA1)"}}{{"true"}}{{break}}{{end}}{{end}}'))
 
 	ifeq ($(HAS_SHA1_TAG),'true')
 		@@echo ✓ tagging $(1):$(GIT_SHA1) to $(1):$(GIT_BRANCH_NORM)
 		@@$(OC) -n $(OC_PROJECT) tag $(1):$(GIT_SHA1) $(1):$(GIT_BRANCH_NORM)
 	else
-		IMAGE_ID = @@$(OC) -n $(OC_PROJECT) get istag/$(1):$(GIT_BRANCH_NORM) -o=go-template='\
+		@@$(eval IMAGE_ID = $(shell $(OC) -n $(OC_PROJECT) get istag/$(1):$(GIT_BRANCH_NORM) -o=go-template='\
 {{$$commitId := index .image.dockerImageMetadata.Config.Labels "io.openshift.build.commit.id"}}\
 {{if eq $$commitId "$(GIT_SHA1)"}}\
 {{.image.dockerImageMetadata.Id}}\
-{{end}}'
+{{end}}'))
 		ifeq ($(IMAGE_ID),'')
 			@@echo ✘ Image stream $(1):$(GIT_BRANCH_NORM) for commit $(GIT_SHA1) was not found.
 			@@echo This is likely due to the fact that $(1):$(GIT_BRANCH_NORM) was overwritten by a parallel build

--- a/oc.mk
+++ b/oc.mk
@@ -8,6 +8,7 @@ OC_REGISTRY=docker-registry.default.svc:5000
 OC_REGISTRY_EXT=docker-registry.pathfinder.gov.bc.ca
 OC_PROJECT=$(shell echo "$${ENVIRONMENT:-$${OC_PROJECT}}")
 OC_TEMPLATE_VARS=PREFIX=$(PROJECT_PREFIX) GIT_SHA1=$(GIT_SHA1) GIT_BRANCH_NORM=$(GIT_BRANCH_NORM)
+THIS_FOLDER := $(abspath $(realpath $(lastword $(MAKEFILE_LIST)))/../)
 
 define oc_whoami
 	@@WHOAMI="$(shell $(OC) whoami)"; \
@@ -51,7 +52,7 @@ define oc_configure
 endef
 
 define oc_build
-	@@./lib/oc_build.sh $(OC) $(OC_PROJECT) $(1) $(GIT_BRANCH_NORM) $(GIT_SHA1)
+	@@${THIS_FOLDER}/lib/oc_build.sh $(OC) $(OC_PROJECT) $(1) $(GIT_BRANCH_NORM) $(GIT_SHA1)
 endef
 
 define oc_promote

--- a/oc.mk
+++ b/oc.mk
@@ -52,19 +52,25 @@ define oc_build
 	@@echo ✓ building $(1)
 	@@$(OC) -n $(OC_PROJECT) start-build $(1) --follow
 
-	IMAGE_ID = @@$(OC) -n $(OC_PROJECT) get istag/$(1):$(GIT_BRANCH_NORM) -o=go-template='\
+	HAS_SHA1_TAG = @@$(OC) -n $(OC_PROJECT) get is/$(1) -o=go-template='{{range .status.tags}}{{if eq .tag "$(GIT_SHA1)"}}{{"true"}}{{break}}{{end}}{{end}}'
+
+	ifeq ($(HAS_SHA1_TAG),'true')
+		@@echo ✓ tagging $(1):$(GIT_SHA1) to $(1):$(GIT_BRANCH_NORM)
+		@@$(OC) -n $(OC_PROJECT) tag $(1):$(GIT_SHA1) $(1):$(GIT_BRANCH_NORM)
+	else
+		IMAGE_ID = @@$(OC) -n $(OC_PROJECT) get istag/$(1):$(GIT_BRANCH_NORM) -o=go-template='\
 {{$$commitId := index .image.dockerImageMetadata.Config.Labels "io.openshift.build.commit.id"}}\
 {{if eq $$commitId "$(GIT_SHA1)"}}\
 {{.image.dockerImageMetadata.Id}}\
 {{end}}'
-
-	ifeq ($(IMAGE_ID),'')
-		@@echo ✘ Image stream $(1):$(GIT_BRANCH_NORM) for commit $(GIT_SHA1) could not be found.
-		@@echo This is likely due to the fact that $(1):$(GIT_BRANCH_NORM) was overwritten by a parallel build
-		@@exit 1
-	else
-		@@echo ✓ tagging $(1)@$(IMAGE_ID) to $(1):$(GIT_SHA1)
-		@@$(OC) -n $(OC_PROJECT) tag $(1)@$(IMAGE_ID) $(1):$(GIT_SHA1)
+		ifeq ($(IMAGE_ID),'')
+			@@echo ✘ Image stream $(1):$(GIT_BRANCH_NORM) for commit $(GIT_SHA1) was not found.
+			@@echo This is likely due to the fact that $(1):$(GIT_BRANCH_NORM) was overwritten by a parallel build
+			@@exit 1
+		else
+			@@echo ✓ tagging $(1)@$(IMAGE_ID) to $(1):$(GIT_SHA1)
+			@@$(OC) -n $(OC_PROJECT) tag $(1)@$(IMAGE_ID) $(1):$(GIT_SHA1)
+		endif
 	endif
 endef
 

--- a/oc.mk
+++ b/oc.mk
@@ -57,13 +57,15 @@ define oc_build
 		$(OC) -n $(OC_PROJECT) tag $(1):$(GIT_SHA1) $(1):$(GIT_BRANCH_NORM); \
 	else \
 		BUILD_VERSION=$$($(OC) -n $(OC_PROJECT) get bc/$(1) -o=go-template='{{.status.lastVersion}}'); \
-		IMAGE_ID=$$($(OC) -n $(OC_PROJECT) get build/$(1)-$$BUILD_VERSION -o=go-template='{{if (index .metadata.labels "git_sha1")}}{{if eq (index .metadata.labels "git_sha1") "$(GIT_SHA1)"}}{{.status.output.to.imageDigest}}{{end}}{{end}}'); \
-		if [[ ! -z $$IMAGE_ID ]]; then \
+		while [ -z $$IMAGE_ID ]; do \
+			IMAGE_ID=$$($(OC) -n $(OC_PROJECT) get build/$(1)-$$BUILD_VERSION -o=go-template='{{if (index .metadata.labels "git_sha1")}}{{if eq (index .metadata.labels "git_sha1") "$(GIT_SHA1)"}}{{.status.output.to.imageDigest}}{{end}}{{end}}'); \
+			BUILD_VERSION=$$[$$BUILD_VERSION - 1]; \
+		done; \
+		if [[ $$IMAGE_ID == sha256* ]]; then \
 			echo "✓ tagging $(1)@$$IMAGE_ID to $(1):$(GIT_SHA1)"; \
 			$(OC) -n $(OC_PROJECT) tag $(1)@$$IMAGE_ID $(1):$(GIT_SHA1); \
 		else \
 			echo "✘ Image stream $(1):$(GIT_BRANCH_NORM) for commit $(GIT_SHA1) was not found."; \
-			echo "This is likely due to the fact that $(1):$(GIT_BRANCH_NORM) was overwritten by a parallel build"; \
 			exit 1; \
 		fi; \
 	fi;

--- a/oc.mk
+++ b/oc.mk
@@ -26,7 +26,8 @@ endef
 
 define oc_validate
 	$(OC) process --ignore-unknown-parameters=true -f $(1) --local $(2) \
-		| $(OC) -n "$(OC_PROJECT)" apply --dry-run --validate -f- >/dev/null \
+		| jq '.items[0].metadata.labels=(.items[0].metadata.labels + { "cas-pipeline/commit.id":"$(GIT_SHA1)","cas-pipeline/commit.ref":"$(GIT_BRANCH)" })' \
+		|  $(OC) -n "$(OC_PROJECT)" apply --dry-run --validate -f- >/dev/null \
 		&& echo ✓ $(1) is valid \
 		|| (echo ✘ $(1) is invalid && exit 1)
 endef
@@ -39,7 +40,7 @@ endef
 
 define oc_apply
 	$(OC) process --ignore-unknown-parameters=true -f $(1) $(2) \
-		| jq '.items[0].metadata.labels=(.items[0].metadata.labels + { "cas-pipeline/source-location":"$(GIT_ORIGIN_URL)", "cas-pipeline/commit.id":"$(GIT_SHA1)","cas-pipeline/commit.ref":"$(GIT_BRANCH)" })' \
+		| jq '.items[0].metadata.labels=(.items[0].metadata.labels + { "cas-pipeline/commit.id":"$(GIT_SHA1)","cas-pipeline/commit.ref":"$(GIT_BRANCH)" })' \
 		| $(OC) -n "$(3)" apply --wait --overwrite --validate -f-
 endef
 

--- a/oc.mk
+++ b/oc.mk
@@ -27,7 +27,7 @@ endef
 
 define oc_validate
 	$(OC) process --ignore-unknown-parameters=true -f $(1) --local $(2) \
-		| jq '.items[] | select(.kind == "BuildConfig").metadata.labels=(.items.metadata.labels + { "cas-pipeline/commit.id":"$(GIT_SHA1)","cas-pipeline/commit.ref":"$(GIT_BRANCH)" })' \
+		| jq '.items[].metadata.labels=(.items[].metadata.labels + { "cas-pipeline/commit.id":"$(GIT_SHA1)" })' \
 		|  $(OC) -n "$(OC_PROJECT)" apply --dry-run --validate -f- >/dev/null \
 		&& echo ✓ $(1) is valid \
 		|| (echo ✘ $(1) is invalid && exit 1)
@@ -41,7 +41,7 @@ endef
 
 define oc_apply
 	$(OC) process --ignore-unknown-parameters=true -f $(1) $(2) \
-		| jq '.items[] | select(.kind == "BuildConfig").metadata.labels=(.items.metadata.labels + { "cas-pipeline/commit.id":"$(GIT_SHA1)","cas-pipeline/commit.ref":"$(GIT_BRANCH)" })' \
+		| jq '.items[].metadata.labels=(.items[].metadata.labels + { "cas-pipeline/commit.id":"$(GIT_SHA1)" })' \
 		| $(OC) -n "$(3)" apply --wait --overwrite --validate -f-
 endef
 

--- a/oc.mk
+++ b/oc.mk
@@ -52,7 +52,7 @@ define oc_configure
 endef
 
 define oc_build
-	@@${THIS_FOLDER}/lib/oc_build.sh $(OC) $(OC_PROJECT) $(1) $(GIT_BRANCH_NORM) $(GIT_SHA1)
+	@@${THIS_FOLDER}/lib/oc_build.sh $(OC) $(OC_PROJECT) $(1) $(GIT_BRANCH_NORM) $(GIT_SHA1) "$(OC_TEMPLATE_VARS)"
 endef
 
 define oc_promote

--- a/oc.mk
+++ b/oc.mk
@@ -27,7 +27,7 @@ endef
 
 define oc_validate
 	$(OC) process --ignore-unknown-parameters=true -f $(1) --local $(2) \
-		| jq '.items[0].metadata.labels=(.items[0].metadata.labels + { "cas-pipeline/commit.id":"$(GIT_SHA1)","cas-pipeline/commit.ref":"$(GIT_BRANCH)" })' \
+		| jq '.items[] | select(.kind == "BuildConfig").metadata.labels=(.items.metadata.labels + { "cas-pipeline/commit.id":"$(GIT_SHA1)","cas-pipeline/commit.ref":"$(GIT_BRANCH)" })' \
 		|  $(OC) -n "$(OC_PROJECT)" apply --dry-run --validate -f- >/dev/null \
 		&& echo ✓ $(1) is valid \
 		|| (echo ✘ $(1) is invalid && exit 1)
@@ -41,7 +41,7 @@ endef
 
 define oc_apply
 	$(OC) process --ignore-unknown-parameters=true -f $(1) $(2) \
-		| jq '.items[0].metadata.labels=(.items[0].metadata.labels + { "cas-pipeline/commit.id":"$(GIT_SHA1)","cas-pipeline/commit.ref":"$(GIT_BRANCH)" })' \
+		| jq '.items[] | select(.kind == "BuildConfig").metadata.labels=(.items.metadata.labels + { "cas-pipeline/commit.id":"$(GIT_SHA1)","cas-pipeline/commit.ref":"$(GIT_BRANCH)" })' \
 		| $(OC) -n "$(3)" apply --wait --overwrite --validate -f-
 endef
 


### PR DESCRIPTION
The `oc_build` function now takes care of creating/updating the BuildConfig, and allows the build configs to output to an ImageStream tag using `GIT_BRANCH_NORM` instead of `SHA1`