### PR TITLE
always use git to find the current sha1

### DIFF
--- a/git.mk
+++ b/git.mk
@@ -1,8 +1,8 @@
 GIT=$(shell command -v git)
-GIT_SHA1=$(shell echo "$${CIRCLE_SHA1:-`$(GIT) rev-parse HEAD`}")
-GIT_BRANCH=$(strip $(shell $(GIT) rev-parse --abbrev-ref HEAD))
-GIT_BRANCH_NORM=$(subst /,-,$(GIT_BRANCH)) # openshift doesn't like slashes
-
 ifeq ($(GIT),)
 $(error 'git' not found in $$PATH)
 endif
+
+GIT_SHA1=$(shell $(GIT) rev-parse HEAD)
+GIT_BRANCH=$(strip $(shell $(GIT) rev-parse --abbrev-ref HEAD))
+GIT_BRANCH_NORM=$(subst /,-,$(GIT_BRANCH)) # openshift doesn't like slashes


### PR DESCRIPTION
`$CIRCLE_SHA1` does not apply to submodules so we can't `make install` from inside them on circle