### PR TITLE
feat: add watch to list of allowed verbs for pods

### DIFF
--- a/openshift/authorize/role/deployer.yml
+++ b/openshift/authorize/role/deployer.yml
@@ -59,11 +59,13 @@ objects:
           - pods/exec
           - pods/log
         verbs:
+          - watch
           - list
           - get
           - create
           - update
           - patch
+          - delete
       - apiGroups:
           - apps.openshift.io
         attributeRestrictions: null
@@ -128,3 +130,50 @@ objects:
           - create
           - delete
           - get
+      - apiGroups:
+          - policy
+        resources:
+          - poddisruptionbudgets
+        verbs:
+          - get
+          - create
+          - update
+          - patch
+          - delete
+      - apiGroups:
+          - ""
+        resources:
+          - serviceaccounts
+        verbs:
+          - get
+          - list
+          - create
+          - update
+          - patch
+          - delete
+      - apiGroups:
+          - "rbac.authorization.k8s.io"
+          - "authorization.openshift.io"
+        resources:
+          - roles
+          - rolebindings
+        verbs:
+          - get
+          - list
+          - create
+          - update
+          - patch
+          - delete
+      - apiGroups:
+          - extensions
+          - apps
+        resources:
+          - deployments
+          - replicasets
+        verbs:
+          - get
+          - list
+          - create
+          - update
+          - patch
+          - delete


### PR DESCRIPTION
needed for delegation to airflow, which watches its own pod logs