### PR TITLE
feat: allow linter to get rolebindings

### DIFF
--- a/openshift/authorize/role/linter.yml
+++ b/openshift/authorize/role/linter.yml
@@ -822,6 +822,7 @@ objects:
     - rbac.authorization.k8s.io
     attributeRestrictions: null
     resources:
+    - rolebindings
     - roles
     verbs:
     - get


### PR DESCRIPTION
required for https://github.com/bcgov/cas-ciip-portal/pull/878 (the `make authorize` command was already run, allowing that PR's CI workflow to pass)