### PR TITLE
Feature: OCP4 infrastructure

### DIFF
--- a/helm/cas-provision/templates/linter/linterRole.yaml
+++ b/helm/cas-provision/templates/linter/linterRole.yaml
@@ -499,5 +499,11 @@ rules:
   - roles
   verbs:
   - get
+- apiGroups:
+    - security.devops.gov.bc.ca
+  resources:
+    - networksecuritypolicies
+  - verbs:
+    - get
 
 {{ end }}

--- a/helm/cas-provision/templates/namespacePrefixSecret.yaml
+++ b/helm/cas-provision/templates/namespacePrefixSecret.yaml
@@ -1,0 +1,16 @@
+# Only render template in -tools
+{{- if hasSuffix "-tools" .Release.Namespace }}
+
+kind: Secret
+apiVersion: v1
+metadata:
+  name: cas-namespace-prefixes
+  labels:
+    created-by: cas-pipeline
+type: Opaque
+stringData:
+  airflow-namespace-prefix: "{{ .Values.namespacePrefixes.airflow }}"
+  ggircs-namespace-prefix: "{{ .Values.namespacePrefixes.ggircs }}"
+  ciip-namespace-prefix: "{{ .Values.namespacePrefixes.ciip }}"
+
+{{- end }}


### PR DESCRIPTION
- namespace prefixes are available in the -tools namespaces
- linter role can lint network security policy objects