### PR TITLE
feat: acme url secret

### DIFF
--- a/helm/cas-provision/templates/acmeUrlSecret.yaml
+++ b/helm/cas-provision/templates/acmeUrlSecret.yaml
@@ -1,0 +1,14 @@
+# Only add secret in prod namespaces
+{{- if hasSuffix "-prod" .Release.Namespace }}
+
+kind: Secret
+apiVersion: v1
+metadata:
+  name: cas-acme-url
+  labels:
+{{ include "cas-provision.labels" . | indent 4 }}
+type: Opaque
+stringData:
+  url: "{{ .Values.acme.url }}"
+
+{{- end }}

--- a/helm/cas-provision/values.yaml
+++ b/helm/cas-provision/values.yaml
@@ -31,3 +31,6 @@ sysdigTeam:
   users:
     - name: some@email.com
       role: ROLE_TEAM_MANAGER 
+
+acme:
+  url: "" # The url against which acme challenges will be executed


### PR DESCRIPTION
Adds a template to the provisioning chart: A secret containing the acme url as defined in the supplied `.values.yaml` file.
This template only applies to `-prod` environments.

Secret is called `cas-acme-url`