### PR TITLE
feat(cas-provision): deployer role can list routes

### DIFF
--- a/helm/cas-provision/templates/deployer/deployerRole.yaml
+++ b/helm/cas-provision/templates/deployer/deployerRole.yaml
@@ -95,6 +95,7 @@ rules:
     resources:
       - routes
     verbs:
+      - list
       - get
       - create
       - update


### PR DESCRIPTION
This was applied manually where needed because of #67 