### PR TITLE
feat: allow linter to see secrets

### DIFF
--- a/helm/cas-provision/templates/linter/linterRole.yaml
+++ b/helm/cas-provision/templates/linter/linterRole.yaml
@@ -22,6 +22,7 @@ rules:
   - replicationcontrollers/scale
   - serviceaccounts
   - services
+  - secrets
   verbs:
   - get
   - list


### PR DESCRIPTION
Preventing the linter from seeing secrets is preventing the linting of some helm charts