### PR TITLE
Feat: airflow github oauth client secrets

### DIFF
--- a/helm/cas-provision/templates/airflowOAuth.yaml
+++ b/helm/cas-provision/templates/airflowOAuth.yaml
@@ -1,0 +1,11 @@
+{{- if and (hasPrefix .Values.namespacePrefixes.airflow .Release.Namespace)}}
+kind: Secret
+apiVersion: v1
+metadata:
+  name: airflow-oauth
+  labels: {{ include "cas-provision.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  clientId: {{ .Values.airflowOAuth.clientId }}
+  clientSecret: {{ .Values.airflowOAuth.clientSecret }}
+{{- end }}

--- a/helm/cas-provision/values.yaml
+++ b/helm/cas-provision/values.yaml
@@ -61,3 +61,7 @@ kcClientSecrets:
     dev: ~
     test: ~
     prod: ~
+
+airflowOAuth:
+  clientId: ~
+  clientSecret: ~


### PR DESCRIPTION
Add a secret to hold the `clientId` and `clientSecret` for CAS Airflow's new GitHub authentication.

Related cas-airflow branch: https://github.com/bcgov/cas-airflow/pull/151