### PR TITLE
chore: add github OAuth secrets for airflow test and prod

### DIFF
--- a/helm/cas-provision/templates/airflowOAuth.yaml
+++ b/helm/cas-provision/templates/airflowOAuth.yaml
@@ -6,6 +6,17 @@ metadata:
   labels: {{ include "cas-provision.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  clientId: {{ .Values.airflowOAuth.clientId }}
-  clientSecret: {{ .Values.airflowOAuth.clientSecret }}
+{{- if hasSuffix "-dev" .Release.Namespace }}
+  clientId: {{ .Values.airflowOAuth.dev.clientId }}
+  clientSecret: {{ .Values.airflowOAuth.dev.clientSecret }}
+{{- end }}
+{{- if hasSuffix "-test" .Release.Namespace }}
+  clientId: {{ .Values.airflowOAuth.test.clientId }}
+  clientSecret: {{ .Values.airflowOAuth.test.clientSecret }}
+{{- end }}
+{{- if hasSuffix "-prod" .Release.Namespace }}
+  clientId: {{ .Values.airflowOAuth.prod.clientId }}
+  clientSecret: {{ .Values.airflowOAuth.prod.clientSecret }}
+{{- end }}
+
 {{- end }}

--- a/helm/cas-provision/templates/airflowOAuth.yaml
+++ b/helm/cas-provision/templates/airflowOAuth.yaml
@@ -1,4 +1,4 @@
-{{- if and (hasPrefix .Values.namespacePrefixes.airflow .Release.Namespace)}}
+{{- if hasPrefix .Values.namespacePrefixes.airflow .Release.Namespace}}
 kind: Secret
 apiVersion: v1
 metadata:

--- a/helm/cas-provision/values.yaml
+++ b/helm/cas-provision/values.yaml
@@ -63,5 +63,12 @@ kcClientSecrets:
     prod: ~
 
 airflowOAuth:
-  clientId: ~
-  clientSecret: ~
+  dev:
+    clientId: ~
+    clientSecret: ~
+  test:
+    clientId: ~
+    clientSecret: ~
+  prod:
+    clientId: ~
+    clientSecret: ~


### PR DESCRIPTION
Created client secrets for CAS Airflow test and prod using bc-cas github account. 
If you sign in using bc-cas and go to Settings -> Developer settings -> OAuth apps, you will see all three apps, one for each namespace. In these we specify the homepage and auth callback urls, as well as generate client secrets.

The `.values.yaml` file was updated with the new secrets and uploaded to 1Password.