### PR TITLE
fix: exclude script caller from delete rolebinding command

### DIFF
--- a/lib/oc_add_gh_team_to_nsp.sh
+++ b/lib/oc_add_gh_team_to_nsp.sh
@@ -82,13 +82,13 @@ __dirname="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 echo "Retriving members of $org/$team"
 
 team_members=$(curl --silent -H "Authorization: token $token" https://api.github.com/orgs/"$org"/teams/"$team"/members | jq -r '.[] | .login | ascii_downcase')
+# Extract your GitHub username
+my_github_username=$(oc whoami | awk -F'@' '{print $1}')
 
 for prefix in "${prefixes[@]}"; do
   for suffix in "${suffixes[@]}"; do
     namespace=$prefix-$suffix
     if ! $dry_run; then
-      # Extract your GitHub username
-      my_github_username=$(oc whoami | awk -F'@' '{print $1}')
       # Temporarily change the GH_TEAM of the user calling this script so that their permissions are not removed in the following command
       oc process -f "$__dirname"/clusterRoleBinding.yaml GH_LOGIN="$my_github_username" GH_TEAM="temp_admin" NAMESPACE="$namespace" ROLE="$role" | \
         oc -n "$namespace" apply --wait --overwrite --validate -f-

--- a/lib/oc_add_gh_team_to_nsp.sh
+++ b/lib/oc_add_gh_team_to_nsp.sh
@@ -87,11 +87,18 @@ for prefix in "${prefixes[@]}"; do
   for suffix in "${suffixes[@]}"; do
     namespace=$prefix-$suffix
     if ! $dry_run; then
+      # Extract your GitHub username
+      my_github_username=$(oc whoami | awk -F'@' '{print $1}')
+      # Temporarily change the GH_TEAM of the user calling this script so that their permissions are not removed in the following command
+      oc process -f "$__dirname"/clusterRoleBinding.yaml GH_LOGIN="$my_github_username" GH_TEAM="temp_admin" NAMESPACE="$namespace" ROLE="$role" | \
+        oc -n "$namespace" apply --wait --overwrite --validate -f-
+      # Remove rolebindings from namespace
       oc -n "$namespace" delete rolebinding -l created-by=cas-pipeline,gh-team="${org}_$team"
     fi
     for login in $team_members; do
       echo "Binding GitHub user $login to role $role in $namespace"
       if ! $dry_run; then
+        # Add namespace permissions for members in the specified GH teams
         oc process -f "$__dirname"/clusterRoleBinding.yaml GH_LOGIN="$login" GH_TEAM="${org}_$team" NAMESPACE="$namespace" ROLE="$role" | \
         oc -n "$namespace" apply --wait --overwrite --validate -f-
       fi


### PR DESCRIPTION
[CARD 78](https://app.zenhub.com/workspaces/climate-action-secretariat-60ca4121764d710011481ca2/issues/gh/bcgov/cas-pipeline/78)