### PR TITLE
feat: add Terraform workspace support to chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,18 +57,6 @@ Prior to using Helm to deploy applications to the OpenShift cluster, the CAS tea
 
 ## Terraform in CAS repos
 
-### Components
-
-#### `~/helm/terraform-bucket-provision/`
-
-This repo contains a Helm chart that contains a job that will import and run Terraform files. It deploys at the pre-install, pre-upgrade hooks. This chart references secrets and config that is deployed to a namespace when a project is provisioned by *`cas-pipeline`* (credentials, project_id, kubeconfig, terraform backendconfig).
-
-`terraform-apply.yaml`: This file defines the Job that deploys a container to run Terraform. Secrets (deployed by `make provision`) contain the credentials and `.tfbackend` Terraform uses to access the GCP buckets where it stores state. The `terraform-modules.yaml` ConfigMap is what pulls in the Terraform scripts that will be run.
-
-#### `~/helm/terraform-bucket-provision/terraform`
-
-In tandem with the Helm chart is a Terraform module that creates GCP storage buckets, service accounts to access those buckets (admins and viewers) and injects those credentials into OpenShift for usage. These modules are pulled in via a configMap which pulls all files from this charts `/terraform` directory. These are bundled with the chart as the way we use Terraform is currently identical in our CAS projects.
-
 ### Usage
 
 1. Import the Helm Chart into your project's main chart as a dependency.
@@ -82,4 +70,15 @@ terraform-bucket-provision:
     workspace: example # This value is OPTIONAL, only set if required
 ```
 
----
+### Components
+
+#### `~/helm/terraform-bucket-provision/`
+
+This repo contains a Helm chart that contains a job that will import and run Terraform files. It deploys at the pre-install, pre-upgrade hooks. This chart references secrets and config that is deployed to a namespace when a project is provisioned by *`cas-pipeline`* (credentials, project_id, kubeconfig, terraform backendconfig).
+
+`terraform-apply.yaml`: This file defines the Job that deploys a container to run Terraform. Secrets (deployed by `make provision`) contain the credentials and `.tfbackend` Terraform uses to access the GCP buckets where it stores state. The `terraform-modules.yaml` ConfigMap is what pulls in the Terraform scripts that will be run.
+
+#### `~/helm/terraform-bucket-provision/terraform`
+
+In tandem with the Helm chart is a Terraform module that creates GCP storage buckets, service accounts to access those buckets (admins and viewers) and injects those credentials into OpenShift for usage. These modules are pulled in via a configMap which pulls all files from this charts `/terraform` directory. These are bundled with the chart as the way we use Terraform is currently identical in our CAS projects.
+

--- a/README.md
+++ b/README.md
@@ -73,11 +73,13 @@ In tandem with the Helm chart is a Terraform module that creates GCP storage buc
 
 1. Import the Helm Chart into your project's main chart as a dependency.
 2. Update your `values.yaml` (and any environmental versions of values) with those required by the terraform-bucket-provision chart:
+    > 2a. If the project shares a namespace with another one (as is the case with `cas-metabase` sharing `cas-ggircs`'s namespace), use the `workspace` value with anything other than default to create a seperate Terraform workspace in the state to avoid overwriting.
 
 ```yaml
 terraform-bucket-provision:
   terraform:
     namespace_apps: '["example-project-backups", "example-project-uploads"]'
+    workspace: example # This value is OPTIONAL, only set if required
 ```
 
 ---

--- a/helm/terraform-bucket-provision/Chart.yaml
+++ b/helm/terraform-bucket-provision/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: terraform-bucket-provision
 description: A chart to deploy a job to run terraform that utilizes terraform modules to create storage buckets and associated service accounts.
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "1.16.0"

--- a/helm/terraform-bucket-provision/templates/terraform-apply.yaml
+++ b/helm/terraform-bucket-provision/templates/terraform-apply.yaml
@@ -55,6 +55,7 @@ spec:
               cd working;
               export TF_VAR_kubernetes_token=$( cat /var/run/secrets/kubernetes.io/serviceaccount/token );
               terraform init -backend-config=/etc/tf/gcs.tfbackend;
+              terraform workspace select -or-create {{ .Values.terraform.workspace }};
               terraform apply -var="kubernetes_host=$kubernetes_host" -auto-approve;
       restartPolicy: Never
       volumes:

--- a/helm/terraform-bucket-provision/values.yaml
+++ b/helm/terraform-bucket-provision/values.yaml
@@ -16,6 +16,7 @@ resources:
 
 terraform:
   namespace_apps: ~
+  workspace: default
 
 serviceAccount:
   name: "terraform-kubernetes-service-account"


### PR DESCRIPTION
Supports [this update to cas-metabase](https://github.com/orgs/bcgov/projects/123/views/1?filterQuery=-status%3Adone+metabase&pane=issue&itemId=53442468)
The initial configuration of the Terraform chart worked was set up to only handle 1 GitHub repo/Helm job per namespace. This became an issue with `cas-metabase`, which runs within `cas-ggircs`'s namespaces. As they were set up, each of these would want to destroy the other's objects within state each time they were run. To alleviate this, the chart now supports an optional `terraform.workspace` value parameter, which will create/use a workspace within the same state, preventing overwrites. This allows both projects to utilize the same configuration (ie. `gcs.tfbackend`), credentials (from GCP), secrets and similar shared pieces.

## Changes 🚧

- added `terraform.workspace` to chart's Values, with a default of `default`.
- added command to switch-or-create active workspace on `terraform-job` execution.
- bumped chart version.