### PR TITLE
feat/99 sidecar logging chart

### DIFF
--- a/helm/cas-logging-sidecar/.helmignore
+++ b/helm/cas-logging-sidecar/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/cas-logging-sidecar/Chart.yaml
+++ b/helm/cas-logging-sidecar/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: cas-logging-sidecar
+description: A Helm chart to deploy Logging Sidecars to CAS applications.
+
+type: application
+version: 0.0.1
+appVersion: "1.16.0"
+
+# This chart should take a list of applications in the values that the sidecars are associated with. The destination of the logs should also be specified in the values

--- a/helm/cas-logging-sidecar/README.md
+++ b/helm/cas-logging-sidecar/README.md
@@ -27,7 +27,13 @@ See [https://github.com/bcgov/cas-efk](https://github.com/bcgov/cas-efk) for mor
 
     > *Note*: These parameters are used in the configmaps for Fluent Bit and Logrotate.
 
-2. `{{- include }}` the sidecar container and volumes into your deployment file. This must be passed the following paramters: `.podToSidecar`, `.containerToSidecar`, `.logName`, `.tag`. This is done using a dict in the include statement, for example:
+2. Associate the service account from the chart with the pod's template.
+
+    ```yaml
+    spec.template.spec.serviceAccountName: {{ .Release.Name }}-pod-logger
+    ```
+
+3. `{{- include }}` the sidecar container and volumes into your deployment file. This must be passed the following paramters: `.podToSidecar`, `.containerToSidecar`, `.logName`, `.tag`. This is done using a dict in the include statement, for example:
 
     ```yaml
     spec.template.spec.containers:
@@ -55,6 +61,7 @@ metadata:
 spec:
   template:
     spec:
+      serviceAccountName: {{ .Release.Name }}-pod-logger
       containers:
         - name: cas-frontend
           image: cas-frontend:latest

--- a/helm/cas-logging-sidecar/README.md
+++ b/helm/cas-logging-sidecar/README.md
@@ -32,8 +32,6 @@ See [https://github.com/bcgov/cas-efk](https://github.com/bcgov/cas-efk) for mor
     ```yaml
     spec.template.spec.containers:
     {{- include "cas-logging-sidecar.containers" (dict 
-        "releaseName" "cas-cif"
-        "podToSideCar" "cas-cif-front"
         "containerToSidecar" "cas-cif-frontend"
         "logName" .Values.logName
         "host" "elasticsearch.abc123-namespace.svc.cluster.local") | nindent 8 }}
@@ -64,7 +62,8 @@ spec:
             - containerPort: 80
         {{- include "cas-logging-sidecar.containers" (dict 
             "containerToSidecar" .Spec.Template.Spec.Containers.0.Name
-            "logName" .Values.logName) | nindent 8 }}
+            "logName" .Values.logName
+            "host" .Values.host) | nindent 8 }}
       volumes:
         {{- include "cas-logging-sidecar.volumes" . | nindent 8 }}
 ```

--- a/helm/cas-logging-sidecar/README.md
+++ b/helm/cas-logging-sidecar/README.md
@@ -1,0 +1,78 @@
+# CAS Logging Sidecar
+
+This library chart is a template used to deploy a logging sidecar to a pod. The sidecar utilizes Fluent Bit and LogRotate to capture logs from a container within OpenShift and write them to ElasticSearch. The chart includes a service account, role, and role binding that are used to grant the service account access to the logs.
+
+## Usage
+
+1. You will need determine the following parameters and add them into your values.yaml file (These will be under the `cas-logging-sidecar` or whatever you named the subchart in your file):
+
+```yaml
+  host: ~
+  index: ~
+  prefix: ~
+  tag: ~
+  logName: ~
+```
+
+> *Note*: These parameters are used in the configmap for Fluent Bit and Logrotate.
+
+2. `{{- include }}` the sidecar container and volumes into your deployment file. This must be passed the following paramters: `.podToSidecar`, `.containerToSidecar`, `.logName`, `.tag`. This is done using a dict in the include statement, for example:
+
+```yaml
+spec.template.spec.containers:
+{{- include "cas-logging-sidecar.containers" (dict 
+    "podToSidecar" "cas-cif"
+    "containerToSidecar" "cas-cif-frontend"
+    "logName" .Values.logName) | nindent 8 }}
+
+spec.template.spec.volumes:
+{{- include "cas-logging-sidecar.volumes" . | nindent 8 }}
+```
+
+> *Note*: You can use `.Values.abc` if you want to use the values from your values.yaml file.
+
+3. There is no 3.
+
+## `_logging-sidecar.yaml` Parameters list
+
+| Parameter | Description | Example |
+| --- | --- | --- |
+| `"podToSidecar"` | The pod where the sidecar should be implemented. | `"cas-cif"` |
+| `"containerToSidecar"` | The container that the sidecar should log for. | `"cas-cif-frontend"` |
+| `"logName"` | The name for the output logfile. **NOTE**: This must match the logname used in `values.yaml`. | `.Values.logName` |
+
+## values.yaml list
+
+| Value | Usage location | Description | Example |
+| --- | --- | --- | --- |
+| `logName` | `fluent-bit-configmap.yaml`, `logrotate-configmap.yaml` | The name for the output logfile. | `cif-frontend-log` |
+| `host` | `fluent-bit-configmap.yaml` | ElasticSearch host to send logs to. | `elasticsearch.abc123-tools.svc.cluster.local` |
+| `index` | `fluent-bit-configmap.yaml` | Index name. | `cif-logs` |
+| `prefix` | `fluent-bit-configmap.yaml` | The index name is composed using a prefix and the date. The last string appended belongs to the date when the data is being generated. | `cif-logs` |
+| `tag` | `fluent-bit-configmap.yaml` | Tag name associated to all records coming from this plugin. | `oc-cif` |
+
+
+## Example use
+
+```yaml
+# templates/cas-frontend-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cas-frontend
+spec:
+  template:
+    spec:
+      containers:
+        - name: cas-frontend
+          image: cas-frontend:latest
+          ports:
+            - containerPort: 80
+        {{- include "cas-logging-sidecar.containers" (dict 
+            "podToSidecar" .Metadata.Name
+            "containerToSidecar" .Spec.Template.Spec.Containers.0.Name
+            "logName" .Values.logName
+            "tag" "cas-frontend" ) | nindent 8 }}
+      volumes:
+        {{- include "cas-logging-sidecar.volumes" . | nindent 8 }}
+```

--- a/helm/cas-logging-sidecar/README.md
+++ b/helm/cas-logging-sidecar/README.md
@@ -4,53 +4,42 @@ This library chart is a template used to deploy a logging sidecar to a pod. The 
 
 ## Usage
 
+0. Add the library chart to your project. This can be done by adding the following to your `Chart.yaml` file:
+
+    ```yaml
+    dependencies:
+      - name: cas-logging-sidecar
+        repository: https://bcgov.github.io/cas-pipeline/
+        version: 0.1.0
+    ```
+
 1. You will need determine the following parameters and add them into your values.yaml file (These will be under the `cas-logging-sidecar` or whatever you named the subchart in your file):
 
-```yaml
-  host: ~
-  index: ~
-  prefix: ~
-  tag: ~
-  logName: ~
-```
+    ```yaml
+      host: ~
+      index: ~
+      prefix: ~
+      tag: ~
+      logName: ~
+    ```
 
-> *Note*: These parameters are used in the configmap for Fluent Bit and Logrotate.
+    > *Note*: These parameters are used in the configmaps for Fluent Bit and Logrotate.
 
 2. `{{- include }}` the sidecar container and volumes into your deployment file. This must be passed the following paramters: `.podToSidecar`, `.containerToSidecar`, `.logName`, `.tag`. This is done using a dict in the include statement, for example:
 
-```yaml
-spec.template.spec.containers:
-{{- include "cas-logging-sidecar.containers" (dict 
-    "containerToSidecar" "cas-cif-frontend"
-    "logName" .Values.logName) | nindent 8 }}
+    ```yaml
+    spec.template.spec.containers:
+    {{- include "cas-logging-sidecar.containers" (dict 
+        "containerToSidecar" "cas-cif-frontend"
+        "logName" .Values.logName) | nindent 8 }}
 
-spec.template.spec.volumes:
-{{- include "cas-logging-sidecar.volumes" . | nindent 8 }}
-```
+    spec.template.spec.volumes:
+    {{- include "cas-logging-sidecar.volumes" . | nindent 8 }}
+    ```
 
-> *Note*: You can use `.Values.abc` if you want to use the values from your values.yaml file.
+    > *Note*: You can use `.Values.abc` if you want to use the values from your values.yaml file.
 
-3. There is no 3.
-
-## `_logging-sidecar.yaml` Parameters list
-
-| Parameter | Description | Example |
-| --- | --- | --- |
-| `"containerToSidecar"` | The container that the sidecar should log for. | `"cas-cif-frontend"` |
-| `"logName"` | The name for the output logfile. **NOTE**: This must match the logname used in `values.yaml`. | `.Values.logName` |
-
-## values.yaml list
-
-| Value | Usage location | Description | Example |
-| --- | --- | --- | --- |
-| `logName` | `fluent-bit-configmap.yaml`, `logrotate-configmap.yaml` | The name for the output logfile. | `cif-frontend-log` |
-| `host` | `fluent-bit-configmap.yaml` | ElasticSearch host to send logs to. | `elasticsearch.abc123-tools.svc.cluster.local` |
-| `index` | `fluent-bit-configmap.yaml` | Index name. | `cif-logs` |
-| `prefix` | `fluent-bit-configmap.yaml` | The index name is composed using a prefix and the date. The last string appended belongs to the date when the data is being generated. | `cif-logs` |
-| `tag` | `fluent-bit-configmap.yaml` | Tag name associated to all records coming from this plugin. | `oc-cif` |
-
-
-## Example use
+### Example use
 
 ```yaml
 # templates/cas-frontend-deployment.yaml
@@ -68,8 +57,26 @@ spec:
             - containerPort: 80
         {{- include "cas-logging-sidecar.containers" (dict 
             "containerToSidecar" .Spec.Template.Spec.Containers.0.Name
-            "logName" .Values.logName
-            "tag" "cas-frontend" ) | nindent 8 }}
+            "logName" .Values.logName) | nindent 8 }}
       volumes:
         {{- include "cas-logging-sidecar.volumes" . | nindent 8 }}
 ```
+
+## Inputs
+
+### `_logging-sidecar.yaml` Parameters list
+
+| Parameter | Description | Example |
+| --- | --- | --- |
+| `"containerToSidecar"` | The container that the sidecar should log for. | `"cas-cif-frontend"` |
+| `"logName"` | The name for the output logfile. **NOTE**: This must match the logname used in `values.yaml`. | `.Values.logName` |
+
+### `values.yaml` list
+
+| Value | Usage location | Description | Example |
+| --- | --- | --- | --- |
+| `logName` | `fluent-bit-configmap.yaml`, `logrotate-configmap.yaml` | The name for the output logfile. | `cif-frontend-log` |
+| `host` | `fluent-bit-configmap.yaml` | ElasticSearch host to send logs to. | `elasticsearch.abc123-tools.svc.cluster.local` |
+| `index` | `fluent-bit-configmap.yaml` | Index name. | `cif-logs` |
+| `prefix` | `fluent-bit-configmap.yaml` | The index name is composed using a prefix and the date. The last string appended belongs to the date when the data is being generated. | `cif-logs` |
+| `tag` | `fluent-bit-configmap.yaml` | Tag name associated to all records coming from this plugin. | `oc-cif` |

--- a/helm/cas-logging-sidecar/README.md
+++ b/helm/cas-logging-sidecar/README.md
@@ -32,11 +32,16 @@ See [https://github.com/bcgov/cas-efk](https://github.com/bcgov/cas-efk) for mor
     ```yaml
     spec.template.spec.containers:
     {{- include "cas-logging-sidecar.containers" (dict 
+        "releaseName" "cas-cif"
+        "podToSideCar" "cas-cif-front"
         "containerToSidecar" "cas-cif-frontend"
-        "logName" .Values.logName) | nindent 8 }}
+        "logName" .Values.logName
+        "host" "elasticsearch.abc123-namespace.svc.cluster.local") | nindent 8 }}
 
     spec.template.spec.volumes:
-    {{- include "cas-logging-sidecar.volumes" . | nindent 8 }}
+    {{- include "cas-logging-sidecar.volumes" (dict
+      "releaseName" "cas-cif"
+      ) | nindent 8 }}
     ```
 
     > *Note*: You can use `.Values.abc` if you want to use the values from your values.yaml file.

--- a/helm/cas-logging-sidecar/README.md
+++ b/helm/cas-logging-sidecar/README.md
@@ -21,7 +21,6 @@ This library chart is a template used to deploy a logging sidecar to a pod. The 
 ```yaml
 spec.template.spec.containers:
 {{- include "cas-logging-sidecar.containers" (dict 
-    "podToSidecar" "cas-cif"
     "containerToSidecar" "cas-cif-frontend"
     "logName" .Values.logName) | nindent 8 }}
 
@@ -37,7 +36,6 @@ spec.template.spec.volumes:
 
 | Parameter | Description | Example |
 | --- | --- | --- |
-| `"podToSidecar"` | The pod where the sidecar should be implemented. | `"cas-cif"` |
 | `"containerToSidecar"` | The container that the sidecar should log for. | `"cas-cif-frontend"` |
 | `"logName"` | The name for the output logfile. **NOTE**: This must match the logname used in `values.yaml`. | `.Values.logName` |
 
@@ -69,7 +67,6 @@ spec:
           ports:
             - containerPort: 80
         {{- include "cas-logging-sidecar.containers" (dict 
-            "podToSidecar" .Metadata.Name
             "containerToSidecar" .Spec.Template.Spec.Containers.0.Name
             "logName" .Values.logName
             "tag" "cas-frontend" ) | nindent 8 }}

--- a/helm/cas-logging-sidecar/README.md
+++ b/helm/cas-logging-sidecar/README.md
@@ -2,6 +2,8 @@
 
 This library chart is a template used to deploy a logging sidecar to a pod. The sidecar utilizes Fluent Bit and LogRotate to capture logs from a container within OpenShift and write them to ElasticSearch. The chart includes a service account, role, and role binding that are used to grant the service account access to the logs.
 
+See [https://github.com/bcgov/cas-efk](https://github.com/bcgov/cas-efk) for more information about the EFK stack the logs are sent to.
+
 ## Usage
 
 0. Add the library chart to your project. This can be done by adding the following to your `Chart.yaml` file:

--- a/helm/cas-logging-sidecar/templates/_logging-sidecar.yaml
+++ b/helm/cas-logging-sidecar/templates/_logging-sidecar.yaml
@@ -1,6 +1,13 @@
 # Note: the `.containers` template cannot use any "globals" like `.Release.Name` directly as the `.` context is replaced with the `dict` parameter on use. See README.md for more details
 {{- define "cas-logging-sidecar.containers" -}}
 - name: {{ .containerToSidecar }}-oc-logs-container
+  resources:
+    limits:
+      memory: 64Mi
+      cpu: 100m
+    requests:
+      memory: 16Mi
+      cpu: 10m
   image: openshift/origin-cli:latest
   env:
     - name: POD_NAME
@@ -17,6 +24,13 @@
   - name: shared-logs
     mountPath: /var/log
 - name: {{ .containerToSidecar }}-logrotate-container
+  resources:
+    limits:
+      memory: 64Mi
+      cpu: 100m
+    requests:
+      memory: 16Mi
+      cpu: 10m
   image: skymatic/logrotate
   command:
     - "/bin/sh"
@@ -29,6 +43,13 @@
     mountPath: /etc/logrotate.conf
     subPath: logrotate.conf
 - name: fluent-bit
+  resources:
+    limits:
+      memory: 100Mi
+      cpu: 200m
+    requests:
+      memory: 25Mi
+      cpu: 50m
   image: fluent/fluent-bit:latest
   env:
     - name: FLUENT_ELASTICSEARCH_HOST

--- a/helm/cas-logging-sidecar/templates/_logging-sidecar.yaml
+++ b/helm/cas-logging-sidecar/templates/_logging-sidecar.yaml
@@ -1,0 +1,52 @@
+{{- define "cas-logging-sidecar.containers" -}}
+- name: oc-logs-container
+  image: openshift/origin-cli-latest
+  env:
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: {{ .podToSidecar }}
+    - name: CONTAINER_NAME
+      valueFrom:
+        fieldRef: {{ .containerToSidecar}}
+    - name: LOG_NAME
+      valueFrom:
+        fieldRef: {{ .logName }}
+  command:
+    - "/bin/sh"
+    - "-c"
+    - |
+      echo 'Starting log capture';
+      oc logs -f $POD_NAME -c $CONTAINER_NAME --pod-running-timeout=20s >> /var/log/$LOG_NAME.log;
+  volumeMounts:
+  - name: shared-logs
+    mountPath: /var/log
+- name: logrotate-container
+  image: skymatic/logrotate
+  command:
+    - "/bin/sh"
+    - "-c"
+    - "while true; do logrotate -s /var/log/logrotate.status -f /etc/logrotate.conf; sleep 5; done"
+  volumeMounts:
+  - name: shared-logs
+    mountPath: /var/log
+  - name: logrotate-config
+    mountPath: /etc/logrotate.conf
+    subPath: logrotate.conf
+- name: fluent-bit
+  image: fluent/fluent-bit:latest
+  env: 
+{{- end }}
+{{- define "cas-logging-sidecar.volumes" -}}
+- name: shared-logs
+  emptyDir: {}
+- name: logrotate-config
+  configMap:
+    name: logrotate-configmap
+- name: fluent-bit-config
+  configMap:
+    name: fluent-bit-config
+- name: parsers-config
+  configMap:
+    name: fluent-bit-config
+{{- end }}

--- a/helm/cas-logging-sidecar/templates/_logging-sidecar.yaml
+++ b/helm/cas-logging-sidecar/templates/_logging-sidecar.yaml
@@ -1,27 +1,22 @@
+# Note: the `.containers` template cannot use any "globals" like `.Release.Name` directly as the `.` context is replaced with the `dict` parameter on use. See README.md for more details
 {{- define "cas-logging-sidecar.containers" -}}
-- name: oc-logs-container
-  image: openshift/origin-cli-latest
+- name: {{ .containerToSidecar }}-oc-logs-container
+  image: openshift/origin-cli:latest
   env:
     - name: POD_NAME
       valueFrom:
         fieldRef:
-          fieldPath: .Metadata.Name
-    - name: CONTAINER_NAME
-      valueFrom:
-        fieldRef: {{ .containerToSidecar}}
-    - name: LOG_NAME
-      valueFrom:
-        fieldRef: {{ .logName }}
+          fieldPath: metadata.name
   command:
     - "/bin/sh"
     - "-c"
     - |
       echo 'Starting log capture';
-      oc logs -f $POD_NAME -c $CONTAINER_NAME --pod-running-timeout=20s >> /var/log/$LOG_NAME.log;
+      oc logs -f $POD_NAME -c {{ .containerToSidecar }} --pod-running-timeout=20s >> /var/log/{{ .logName }}.log;
   volumeMounts:
   - name: shared-logs
     mountPath: /var/log
-- name: logrotate-container
+- name: {{ .containerToSidecar }}-logrotate-container
   image: skymatic/logrotate
   command:
     - "/bin/sh"
@@ -35,18 +30,33 @@
     subPath: logrotate.conf
 - name: fluent-bit
   image: fluent/fluent-bit:latest
-  env: 
+  env:
+    - name: FLUENT_ELASTICSEARCH_HOST
+      value: {{ .host }}
+    - name: FLUENT_ELASTICSEARCH_PORT
+      value: "9200"
+  command: [ "/fluent-bit/bin/fluent-bit", "-c", "/var/log/fluent-bit.conf" ]
+  volumeMounts:
+    - name: shared-logs
+      mountPath: /var/log
+    - name: fluent-bit-config
+      mountPath: /var/log/fluent-bit.conf
+      subPath: fluent-bit.conf
+    - name: parsers-config
+      mountPath:  /var/log/parsers.conf
+      subPath: parsers.conf
 {{- end }}
+# Note: The `.volumes` template can use `.Release.Name` directly as it is passed in with the `.` context parameter
 {{- define "cas-logging-sidecar.volumes" -}}
 - name: shared-logs
   emptyDir: {}
 - name: logrotate-config
   configMap:
-    name: {{ .releaseName }}-logrotate-configmap
+    name: {{ .Release.Name }}-logrotate-configmap
 - name: fluent-bit-config
   configMap:
-    name: {{ .releaseName }}-fluent-bit-configmap
+    name: {{ .Release.Name }}-fluent-bit-configmap
 - name: parsers-config
   configMap:
-    name: {{ .releaseName }}-fluent-bit-configmap
+    name: {{ .Release.Name }}-fluent-bit-configmap
 {{- end }}

--- a/helm/cas-logging-sidecar/templates/_logging-sidecar.yaml
+++ b/helm/cas-logging-sidecar/templates/_logging-sidecar.yaml
@@ -5,7 +5,7 @@
     - name: POD_NAME
       valueFrom:
         fieldRef:
-          fieldPath: {{ .podToSidecar }}
+          fieldPath: .Metadata.Name
     - name: CONTAINER_NAME
       valueFrom:
         fieldRef: {{ .containerToSidecar}}

--- a/helm/cas-logging-sidecar/templates/_logging-sidecar.yaml
+++ b/helm/cas-logging-sidecar/templates/_logging-sidecar.yaml
@@ -42,11 +42,11 @@
   emptyDir: {}
 - name: logrotate-config
   configMap:
-    name: logrotate-configmap
+    name: {{ .releaseName }}-logrotate-configmap
 - name: fluent-bit-config
   configMap:
-    name: fluent-bit-config
+    name: {{ .releaseName }}-fluent-bit-configmap
 - name: parsers-config
   configMap:
-    name: fluent-bit-config
+    name: {{ .releaseName }}-fluent-bit-configmap
 {{- end }}

--- a/helm/cas-logging-sidecar/templates/fluent-bit-configmap.yaml
+++ b/helm/cas-logging-sidecar/templates/fluent-bit-configmap.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluent-bit-config
+  namespace: {{ .Release.Namespace }}
+data:
+  fluent-bit.conf: |
+    [SERVICE]
+        Flush                5
+        Daemon               Off
+        Parsers_File         parsers.conf
+        Log_Level            info
+        HTTP_Server          On
+        HTTP_Listen          0.0.0.0
+        HTTP_Port            2020
+    [INPUT]
+        Name                tail
+        Path                /var/log/{{ .logName }}.log
+        Tag                 {{ .tag }}
+        Mem_Buf_Limit        5MB
+        DB                  /var/log/flb_kube.db
+        Refresh_Interval     10
+        Rotate_Wait          5
+        Ignore_Older         24h
+    [OUTPUT]
+        Name                es
+        Match               *
+        Host                {{ .elasticSearchHost }}
+        Port                9200
+        Index               {{ .index }}
+        Logstash_Prefix     {{ .logPrefix }}
+        Logstash_DateFormat %Y.%m.%d
+        Logstash_Format     On
+        Retry_Limit         False
+        Suppress_Type_Name  On
+        Type                _doc
+        Time_Key            @timestamp
+        Time_Key_Format     iso8601
+  parsers.conf: |
+    [PARSER]
+        Name                json
+        Format              json
+        Time_Key            timestamp
+        Decode_Field_as     escaped_utf8 log do_next
+        Decode_Field_as     json log

--- a/helm/cas-logging-sidecar/templates/fluent-bit-configmap.yaml
+++ b/helm/cas-logging-sidecar/templates/fluent-bit-configmap.yaml
@@ -15,8 +15,8 @@ data:
         HTTP_Port            2020
     [INPUT]
         Name                tail
-        Path                /var/log/{{ .logName }}.log
-        Tag                 {{ .tag }}
+        Path                /var/log/{{ .Values.logName }}.log
+        Tag                 {{ .Values.tag }}
         Mem_Buf_Limit        5MB
         DB                  /var/log/flb_kube.db
         Refresh_Interval     10
@@ -25,10 +25,10 @@ data:
     [OUTPUT]
         Name                es
         Match               *
-        Host                {{ .elasticSearchHost }}
+        Host                {{ .Values.host }}
         Port                9200
-        Index               {{ .index }}
-        Logstash_Prefix     {{ .logPrefix }}
+        Index               {{ .Values.index }}
+        Logstash_Prefix     {{ .Values.prefix }}
         Logstash_DateFormat %Y.%m.%d
         Logstash_Format     On
         Retry_Limit         False

--- a/helm/cas-logging-sidecar/templates/fluent-bit-configmap.yaml
+++ b/helm/cas-logging-sidecar/templates/fluent-bit-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: fluent-bit-config
+  name: {{ .Release.Name }}-fluent-bit-configmap
   namespace: {{ .Release.Namespace }}
 data:
   fluent-bit.conf: |

--- a/helm/cas-logging-sidecar/templates/logrotate-configmap.yaml
+++ b/helm/cas-logging-sidecar/templates/logrotate-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: logrotate-configmap
+  name: {{ .Release.Name }}-logrotate-configmap
 data:
   logrotate.conf: |
     /var/log/{{ .Values.logName }}.log {

--- a/helm/cas-logging-sidecar/templates/logrotate-configmap.yaml
+++ b/helm/cas-logging-sidecar/templates/logrotate-configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: logrotate-configmap
 data:
   logrotate.conf: |
-    /var/log/{{ .logName }}.log {
+    /var/log/{{ .Values.logName }}.log {
         size 100M
         missingok
         notifempty

--- a/helm/cas-logging-sidecar/templates/logrotate-configmap.yaml
+++ b/helm/cas-logging-sidecar/templates/logrotate-configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: logrotate-configmap
+data:
+  logrotate.conf: |
+    /var/log/{{ .logName }}.log {
+        size 100M
+        missingok
+        notifempty
+        copytruncate
+        rotate 5
+        compress
+        delaycompress
+        dateext
+        dateformat -%Y%m%d%H%M%S
+    }

--- a/helm/cas-logging-sidecar/templates/pod-logger-role.yaml
+++ b/helm/cas-logging-sidecar/templates/pod-logger-role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: pod-logger-role
+  name: {{ .Release.Name }}-pod-logger-role
   namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups: [""]

--- a/helm/cas-logging-sidecar/templates/pod-logger-role.yaml
+++ b/helm/cas-logging-sidecar/templates/pod-logger-role.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pod-logger-role
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get", "list","watch"]

--- a/helm/cas-logging-sidecar/templates/pod-logger-rolebinding.yaml
+++ b/helm/cas-logging-sidecar/templates/pod-logger-rolebinding.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: pod-logger-rolebinding
+  name: {{ .Release.Name }}-pod-logger-rolebinding
 subjects:
   - kind: ServiceAccount
-    name: pod-logger
+    name: {{ .Release.Name }}-pod-logger
     namespace: {{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: pod-logger-role
+  name: {{ .Release.Name }}-pod-logger-role

--- a/helm/cas-logging-sidecar/templates/pod-logger-rolebinding.yaml
+++ b/helm/cas-logging-sidecar/templates/pod-logger-rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pod-logger-rolebinding
+subjects:
+  - kind: ServiceAccount
+    name: pod-logger
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pod-logger-role

--- a/helm/cas-logging-sidecar/templates/service-account.yaml
+++ b/helm/cas-logging-sidecar/templates/service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pod-logger  # Name of the service account
+  namespace: {{ .Release.Namespace }}

--- a/helm/cas-logging-sidecar/templates/service-account.yaml
+++ b/helm/cas-logging-sidecar/templates/service-account.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: pod-logger  # Name of the service account
+  name: {{ .Release.Name }}-pod-logger  # Name of the service account
   namespace: {{ .Release.Namespace }}

--- a/helm/cas-logging-sidecar/values.yaml
+++ b/helm/cas-logging-sidecar/values.yaml
@@ -1,0 +1,5 @@
+host: ~
+index: ~
+prefix: ~
+tag: ~
+logName: cas-log


### PR DESCRIPTION
Addresses #issue_number. Based heavily on the work that @ayeshmcg did in https://github.com/bcgov/cas-cif/pull/1926. This Library chart is made to be imported into our other deployments and uses two `{{- include ...}}` blocks (one with parameters) to add sidecar containers (fluent bit, openshift cli, logrotate) that follow the defined containers OpenShift logs and transmit them to ElasticSearch. 



## Changes 🚧

- Added Helm library chart.
  - Service account/binding
  - Config maps
  - Sidecar containers & volume partial templates to `include`
- Documentation for usage

## To test 🔬

This template was used alongside a Nginx webserver container in a pod, pointed toward a EFK stack deployed into a tools namespace. Logs written out by Nginx were forward to EFK. 