### PR TITLE
feat/ELK stack 

### DIFF
--- a/helm/cas-efk/.helmignore
+++ b/helm/cas-efk/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/helm/cas-efk/Chart.yaml
+++ b/helm/cas-efk/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: cas-efk
+description: A CAS chart for deploying the EFK stack
+
+type: application
+version: 0.0.1
+appVersion: "8.4.3"

--- a/helm/cas-efk/README.md
+++ b/helm/cas-efk/README.md
@@ -1,0 +1,3 @@
+# CAS ElasticSearch, Fluent Bit, and Kibana
+
+This chart deploys ElasticSearch and Kibana to a namespace, ready to be used alongside the CAS-logging-sidecar chart which comprises the Fluent Bit part of the EFK stack.

--- a/helm/cas-efk/templates/_helpers.tpl
+++ b/helm/cas-efk/templates/_helpers.tpl
@@ -1,0 +1,76 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cas-efk.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cas-efk.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cas-efk.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "cas-efk.labels" -}}
+helm.sh/chart: {{ include "cas-efk.chart" . }}
+{{ include "cas-efk.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "cas-efk.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cas-efk.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cas-efk.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "cas-efk.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Gets the suffix of the namespace.
+*/}}
+{{- define "namespaceSuffix" }}
+{{- (split "-" .Release.Namespace)._1 | trim -}}
+{{- end }}
+
+{{/*
+Gets the prefix of the namespace.
+*/}}
+{{- define "namespacePrefix" }}
+{{- (split "-" .Release.Namespace)._0 | trim -}}
+{{- end }}

--- a/helm/cas-efk/templates/elasticsearch-pvc.yaml
+++ b/helm/cas-efk/templates/elasticsearch-pvc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.elasticsearch.volume }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: elasticsearch
+    app.kubernetes.io/part-of: elasticsearch
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: {{ .Values.elasticsearch.storageClass }}
+  resources:
+    requests:
+      storage: {{ .Values.elasticsearch.storageRequest }}

--- a/helm/cas-efk/templates/elasticsearch-pvc.yaml
+++ b/helm/cas-efk/templates/elasticsearch-pvc.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ .Values.elasticsearch.volume }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: elasticsearch
     app.kubernetes.io/part-of: elasticsearch

--- a/helm/cas-efk/templates/elasticsearch-service.yaml
+++ b/helm/cas-efk/templates/elasticsearch-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: elasticsearch
+spec:
+  selector:
+    app: elasticsearch
+  clusterIP: None
+  ports:
+    - port: {{ .Values.elasticsearch.port.rest }}
+      name: rest
+    - port: {{ .Values.elasticsearch.port.internode }}
+      name: inter-node

--- a/helm/cas-efk/templates/elasticsearch-service.yaml
+++ b/helm/cas-efk/templates/elasticsearch-service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: elasticsearch
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: elasticsearch
 spec:

--- a/helm/cas-efk/templates/elasticsearch-statefulset.yaml
+++ b/helm/cas-efk/templates/elasticsearch-statefulset.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: es-cluster
+  namespace: {{ .Values.namespace }}
+  labels:
+    "app.kubernetes.io/part-of": efk-stack
+spec:
+  serviceName: elasticsearch
+  replicas: {{ .Values.elasticsearch.replicas }}
+  selector:
+    matchLabels:
+      app: elasticsearch
+  template:
+    metadata:
+      labels:
+        app: elasticsearch
+    spec:
+      containers:
+        - name: elasticsearch
+          image: {{ .Values.elasticsearch.image }}:{{ .Values.elasticsearch.version }}
+          resources:
+            requests:
+              cpu: {{ .Values.elasticsearch.cpuRequest }}
+              memory: {{ .Values.elasticsearch.memoryRequest }}
+          ports:
+            - name: rest
+              containerPort: {{ .Values.elasticsearch.port.rest }}
+              protocol: TCP
+            - name: inter-node
+              containerPort: {{ .Values.elasticsearch.port.internode }}
+              protocol: TCP
+          volumeMounts:
+            - name: {{ .Values.elasticsearch.volume }}
+              mountPath: /usr/share/elasticsearch/data
+          env:
+            - name: cluster.name
+              value: elasticsearch
+            - name: node.name
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            {{- $replicaCount := .Values.elasticsearch.replicas | int }}
+            - name: discovery.seed_hosts
+              value: "{{- range $i, $e := until $replicaCount -}}
+                  es-cluster-{{ $i }}.elasticsearch{{- if ne $i (sub $replicaCount 1) }},{{ end }}
+                {{- end }}"
+            - name: cluster.initial_master_nodes
+              value: "{{- range $i, $e := until $replicaCount -}}
+                  es-cluster-{{ $i }}{{- if ne $i (sub $replicaCount 1) }},{{ end }}
+                {{- end }}"
+            - name: ES_JAVA_OPTS
+              value: "-Xms512m -Xmx512m"
+            - name: xpack.security.enabled
+              value: "false"
+      volumes:
+        - name: {{ .Values.elasticsearch.volume }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.elasticsearch.volume }}
+  volumeClaimTemplates:
+    - metadata:
+        name: {{ .Values.elasticsearch.volume }}
+        labels:
+          app: elasticsearch
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: {{ .Values.elasticsearch.storageClass }}
+        resources:
+          requests:
+            storage: {{ .Values.elasticsearch.storageRequest }}

--- a/helm/cas-efk/templates/elasticsearch-statefulset.yaml
+++ b/helm/cas-efk/templates/elasticsearch-statefulset.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: es-cluster
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     "app.kubernetes.io/part-of": efk-stack
 spec:

--- a/helm/cas-efk/templates/kibana-deployment.yaml
+++ b/helm/cas-efk/templates/kibana-deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kibana
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     "app.kubernetes.io/part-of": efk-stack
 spec:

--- a/helm/cas-efk/templates/kibana-deployment.yaml
+++ b/helm/cas-efk/templates/kibana-deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kibana
+  namespace: {{ .Values.namespace }}
+  labels:
+    "app.kubernetes.io/part-of": efk-stack
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kibana
+  template:
+    metadata:
+      labels:
+        app: kibana
+    spec:
+      containers:
+        - name: kibana
+          image: {{ .Values.kibana.image }}:{{ .Values.kibana.version }}
+          resources:
+            requests:
+              cpu: {{ .Values.kibana.cpuRequest }}
+              memory: {{ .Values.kibana.memoryRequest }}
+          env:
+            - name: ELASTICSEARCH_URL
+              value: {{ .Values.elasticsearch.host }}:{{ .Values.elasticsearch.port.rest }}
+          ports:
+            - containerPort: {{ .Values.kibana.port }}

--- a/helm/cas-efk/templates/kibana-route.yaml
+++ b/helm/cas-efk/templates/kibana-route.yaml
@@ -1,0 +1,20 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: kibana
+  labels:
+    "app.kubernetes.io/name": efk-stack
+  annotations:
+    haproxy.router.openshift.io/balance: roundrobin
+spec:
+  host: {{ .Values.kibana.route }}
+  port: 
+    targetPort: kibana
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  to:
+    kind: Service
+    name: kibana
+    namespace: {{ .Values.namespace }}
+    weight: 100

--- a/helm/cas-efk/templates/kibana-route.yaml
+++ b/helm/cas-efk/templates/kibana-route.yaml
@@ -16,5 +16,5 @@ spec:
   to:
     kind: Service
     name: kibana
-    namespace: {{ .Values.namespace }}
+    namespace: {{ .Release.Namespace }}
     weight: 100

--- a/helm/cas-efk/templates/kibana-service.yaml
+++ b/helm/cas-efk/templates/kibana-service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kibana
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     "app.kubernetes.io/part-of": efk-stack
 spec:

--- a/helm/cas-efk/templates/kibana-service.yaml
+++ b/helm/cas-efk/templates/kibana-service.yaml
@@ -9,5 +9,5 @@ spec:
   selector:
     app: kibana
   ports:
-    - name: http
+    - name: kibana
       port: {{ .Values.kibana.port }}

--- a/helm/cas-efk/templates/kibana-service.yaml
+++ b/helm/cas-efk/templates/kibana-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kibana
+  namespace: {{ .Values.namespace }}
+  labels:
+    "app.kubernetes.io/part-of": efk-stack
+spec:
+  selector:
+    app: kibana
+  ports:
+    - name: http
+      port: {{ .Values.kibana.port }}

--- a/helm/cas-efk/values.yaml
+++ b/helm/cas-efk/values.yaml
@@ -1,0 +1,1 @@
+# Default values for cas-efk.

--- a/helm/cas-efk/values.yaml
+++ b/helm/cas-efk/values.yaml
@@ -1,6 +1,4 @@
 # Default values for cas-efk.
-namespace: default
-
 elasticSearchVolume: elasticsearch-data
 elasticsearch:
   image: docker.elastic.co/elasticsearch/elasticsearch

--- a/helm/cas-efk/values.yaml
+++ b/helm/cas-efk/values.yaml
@@ -1,1 +1,18 @@
 # Default values for cas-efk.
+namespace: default
+
+elasticSearchVolume: elasticsearch-data
+elasticsearch:
+  image: docker.elastic.co/elasticsearch/elasticsearch
+  version: 8.4.3
+  replicas: 3
+  host: elasticsearch
+  port:
+    rest: 9200
+    internode: 9300
+  storageRequest: 1Gi
+  volume: elasticsearch-data
+  storageClass: netapp-block-standard
+
+  cpuRequest: 500m
+  memoryRequest: 1Gi

--- a/helm/cas-efk/values.yaml
+++ b/helm/cas-efk/values.yaml
@@ -23,3 +23,6 @@ kibana:
   port: 5601
   cpuRequest: 10m
   memoryRequest: 500Mi
+
+  route: ~
+

--- a/helm/cas-efk/values.yaml
+++ b/helm/cas-efk/values.yaml
@@ -16,3 +16,10 @@ elasticsearch:
 
   cpuRequest: 500m
   memoryRequest: 1Gi
+
+kibana:
+  image: docker.elastic.co/kibana/kibana
+  version: 8.4.3
+  port: 5601
+  cpuRequest: 10m
+  memoryRequest: 500Mi


### PR DESCRIPTION
Addresses #100. Adds a Helm chart for deploying ElasticSearch and Kibana. The logging sidecar from #99 compliments this by sending logs to ES. This ES instance is set to be able to receive logs from other CAS namespaces.

## Changes 🚧

- Added template for ElasticSearch, Kibana and supporting infrastructure

## To test 🔬

Once logged into OpenShift, you can deploy this chart with `helm install -n <Namespace> efk cas-efk/`. You can see the deployment in the OpenShift dashboard, as well as connect to Kibana using `oc port-forward service/kibana 5601:5601` and going to `localhost:5601` in your browser.

## Notes 📝

Due to issues with certificates and inter-node communication, there is another ticket #106 used to set those up. Having simple auth on Kibana requires these certificates, so this chart is not production ready. 
