### PR TITLE
chore: drop CPU limits per new OpenShift best practices

### DIFF
--- a/helm/cas-logging-sidecar/Chart.yaml
+++ b/helm/cas-logging-sidecar/Chart.yaml
@@ -3,7 +3,7 @@ name: cas-logging-sidecar
 description: A Helm chart to deploy Logging Sidecars to CAS applications.
 
 type: application
-version: 0.4.0
+version: 0.4.1
 appVersion: "1.16.0"
 
 # This chart should take a list of applications in the values that the sidecars are associated with. The destination of the logs should also be specified in the values

--- a/helm/cas-logging-sidecar/templates/_logging-sidecar.yaml
+++ b/helm/cas-logging-sidecar/templates/_logging-sidecar.yaml
@@ -4,7 +4,6 @@
   resources:
     limits:
       memory: 64Mi
-      cpu: 100m
     requests:
       memory: 16Mi
       cpu: 10m
@@ -27,7 +26,6 @@
   resources:
     limits:
       memory: 64Mi
-      cpu: 100m
     requests:
       memory: 16Mi
       cpu: 10m
@@ -46,7 +44,6 @@
   resources:
     limits:
       memory: 100Mi
-      cpu: 200m
     requests:
       memory: 25Mi
       cpu: 50m


### PR DESCRIPTION
Removes CPU limits from the sidecars, per the new best practices for OpenShift.
