### PR TITLE
Chore/logging sidecar memory tweaks

### DIFF
--- a/helm/cas-logging-sidecar/Chart.yaml
+++ b/helm/cas-logging-sidecar/Chart.yaml
@@ -3,7 +3,7 @@ name: cas-logging-sidecar
 description: A Helm chart to deploy Logging Sidecars to CAS applications.
 
 type: application
-version: 0.4.1
+version: 0.4.2
 appVersion: "1.16.0"
 
 # This chart should take a list of applications in the values that the sidecars are associated with. The destination of the logs should also be specified in the values

--- a/helm/cas-logging-sidecar/templates/_logging-sidecar.yaml
+++ b/helm/cas-logging-sidecar/templates/_logging-sidecar.yaml
@@ -3,11 +3,11 @@
 - name: {{ .containerToSidecar }}-oc-logs-container
   resources:
     limits:
-      memory: 64Mi
+      memory: 128Mi
     requests:
-      memory: 16Mi
-      cpu: 10m
-  image: openshift/origin-cli:latest
+      memory: 32Mi
+      cpu: 20m
+  image: bitnami/kubectl:latest
   env:
     - name: POD_NAME
       valueFrom:
@@ -18,17 +18,17 @@
     - "-c"
     - |
       echo 'Starting log capture';
-      oc logs -f $POD_NAME -c {{ .containerToSidecar }} --pod-running-timeout=20s >> /var/log/{{ .logName }}.log;
+      kubectl logs -f $POD_NAME -c {{ .containerToSidecar }} --pod-running-timeout=20s | grep "" --line-buffered >> /var/log/{{ .logName }}.log;
   volumeMounts:
   - name: shared-logs
     mountPath: /var/log
 - name: {{ .containerToSidecar }}-logrotate-container
   resources:
     limits:
-      memory: 64Mi
+      memory: 32Mi
     requests:
-      memory: 16Mi
-      cpu: 10m
+      memory: 8Mi
+      cpu: 20m
   image: skymatic/logrotate
   command:
     - "/bin/sh"
@@ -46,7 +46,7 @@
       memory: 100Mi
     requests:
       memory: 25Mi
-      cpu: 50m
+      cpu: 30m
   image: fluent/fluent-bit:latest
   env:
     - name: FLUENT_ELASTICSEARCH_HOST


### PR DESCRIPTION
A few resource tweaks to align with usage we're seeing in sysdig for the logging-sidecar 
- increase memory & cpu for oc-logs
- increase cpu & decrease memory for logrotate
- decrease cpu for fluentbit
- use kubectl instead of oc in the oc-logs container execute string