### PR TITLE
chore: config to allow encrypted files through ClamAV

### DIFF
--- a/gcloud/malware-scanning/config/config.json
+++ b/gcloud/malware-scanning/config/config.json
@@ -13,7 +13,7 @@
   ],
   "ignoreZeroLengthFiles": false,
   "quarantine": {
-    "encryptedFiles": true,
+    "encryptedFiles": false,
     "fileExtensionAllowList": [],
     "fileExtensionDenyList": []
   }


### PR DESCRIPTION
Updated the configs for ClamAV to allow files through that are encrypted. Most likely situation for us is they are "signed", which restricts editing but still allows the files to be used for our needs. 

Terraform updates have been applied to `-dev`, `-test`, and `-prod` with this updated config and the CloudRun application has been cycled. 