### PR TITLE
chore: add job/status config for airflow usage to role

### DIFF
--- a/helm/cas-provision/templates/deployer/deployerRole.yaml
+++ b/helm/cas-provision/templates/deployer/deployerRole.yaml
@@ -149,6 +149,14 @@ rules:
       - delete
       - watch
       - list
+  - apigroups:
+      - batch
+    resources:
+      - jobs/status
+    verbs:
+      - get
+      - list
+      - watch
   - apiGroups:
       - policy
     resources:


### PR DESCRIPTION
An Airflow task checking the status of a job requires additional RBAC configuration. [This task in cas-registration](https://github.com/bcgov/cas-registration/pull/3938) checks for the completion of a restart-rollout and reports back into Airflow. 
