### PR TITLE
chore: updated fluent bit config

### DIFF
--- a/helm/cas-logging-sidecar/templates/fluent-bit-configmap.yaml
+++ b/helm/cas-logging-sidecar/templates/fluent-bit-configmap.yaml
@@ -6,13 +6,19 @@ metadata:
 data:
   fluent-bit.conf: |
     [SERVICE]
-        Flush                5
-        Daemon               Off
-        Parsers_File         parsers.conf
-        Log_Level            info
-        HTTP_Server          On
-        HTTP_Listen          0.0.0.0
-        HTTP_Port            2020
+        Flush                     2
+        Daemon                    Off
+        Parsers_File              parsers.conf
+        Log_Level                 info
+        HTTP_Server               On
+        HTTP_Listen               0.0.0.0
+        HTTP_Port                 2020
+        storage.type              filesystem
+        storage.path              /var/log/flb-storage/
+        storage.sync              normal
+        storage.checksum          off
+        storage.max_chunks_up     128
+        storage.backlog.mem_limit 5M
     [INPUT]
         Name                tail
         Path                /var/log/{{ .Values.logName }}.log


### PR DESCRIPTION
# Fix Fluent Bit HTTP Buffer Overflow Errors

## Problem
Fluent Bit was experiencing HTTP buffer overflow errors when sending logs to Elasticsearch:[warn] [http_client] cannot `increase buffer: current=512000 requested=544768 max=512000 [warn] [output:es:es.0] http_do=-1 URI=/_bulk [warn] [engine] failed to flush chunk '1-1763283270.562037854.flb', retry in 1234 seconds`

This occurred because log chunks were growing larger than the HTTP client's 512KB buffer limit.

## Solution
1. **Added buffer size constraints to INPUT section:**
   - `Buffer_Chunk_Size: 512KB` - Sets initial chunk size to match HTTP client buffer
   - `Buffer_Max_Size: 512KB` - Prevents chunks from growing beyond buffer capacity

2. **Reduced flush interval from 5 to 2 seconds:**
   - Sends smaller batches more frequently
   - Reduces likelihood of buffer overflow
   - Faster log delivery to Elasticsearch

3. Added comprehensive README section explaining storage and buffering settings

## Testing
Verified that the configuration:
-  No longer produces HTTP buffer overflow errors
- Successfully flushes chunks to Elasticsearch
- Maintains proper memory usage (~64MB for chunks with 128 max chunks)
