### PR TITLE
chore: add security context in logging sidecar containers to fix trivy misconfigs in cas-reg

### DIFF
--- a/helm/cas-logging-sidecar/templates/_logging-sidecar.yaml
+++ b/helm/cas-logging-sidecar/templates/_logging-sidecar.yaml
@@ -8,6 +8,12 @@
       memory: 32Mi
       cpu: 20m
   image: ghcr.io/bcgov/cas-log-capture-sidecar:latest
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
   env:
     - name: POD_NAME
       valueFrom:
@@ -29,7 +35,13 @@
     requests:
       memory: 8Mi
       cpu: 20m
-  image: skymatic/logrotate
+  image: skymatic/logrotate:latest
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
   command:
     - "/bin/sh"
     - "-c"
@@ -48,6 +60,12 @@
       memory: 25Mi
       cpu: 30m
   image: fluent/fluent-bit:latest
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+    capabilities:
+      drop:
+        - ALL
   env:
     # "appName": The name of the application that is being logged.
     # Added to the Elastic index name to make it easier to search for logs. Example: "frontend"


### PR DESCRIPTION
Related ticket in reg: https://github.com/bcgov/cas-compliance/issues/533
Related PR: https://github.com/bcgov/cas-registration/pull/4364

These changes fix KSV-0001, KSV-0013, AND KSV-0014 that don't show up in standard trivy scanning because these sidecar dependency charts are built(?) on the pods rather in cas-registration, which will be tackled in this ticket: https://github.com/bcgov/cas-registration/issues/4415