### PR TITLE
Replace gsutil with gcloud storage

### DIFF
--- a/gcloud/malware-scanning/cloudrun-malware-scanner/Dockerfile
+++ b/gcloud/malware-scanning/cloudrun-malware-scanner/Dockerfile
@@ -89,7 +89,6 @@ RUN set -x \
     && clamd --version \
     && freshclam --version \
     && gcloud --version \
-    && gsutil --version \
     && cvdupdate --help
 
 # Copy the source code for the scanner service

--- a/gcloud/malware-scanning/cloudrun-malware-scanner/updateCvdMirror.sh
+++ b/gcloud/malware-scanning/cloudrun-malware-scanner/updateCvdMirror.sh
@@ -56,10 +56,10 @@ while ! {
 do
     # Lockfile exists - check that it has not expired.
     LOCK_EXPIRED_TIMESTAMP="$(date +%s --date="now - ${LOCKFILE_EXPIRY_MINS} minutes")"
-    LOCKFILE_TIMESTAMP=$(gsutil -q cat "${LOCKFILE_PATH}" 2>/dev/null )
+    LOCKFILE_TIMESTAMP=$(gcloud storage cat --quiet "${LOCKFILE_PATH}" 2>/dev/null )
     if [[ "${LOCKFILE_TIMESTAMP}" && "${LOCKFILE_TIMESTAMP}" -lt "${LOCK_EXPIRED_TIMESTAMP}" ]] ; then
         echo "${CMD} ${LOCKFILE_PATH} has expired, removing"
-        gsutil -q rm "${LOCKFILE_PATH}"
+        gcloud storage rm --quiet "${LOCKFILE_PATH}"
         LOCKFILE_TIMESTAMP=""
     else
         # Lockfile created recently, wait for it to be removed or expire
@@ -70,13 +70,13 @@ done
 echo "${CMD} successfully created ${LOCKFILE_PATH}"
 
 # Ensure lockfile is removed on exit.
-trap "echo ${CMD} removing ${LOCKFILE_PATH} ; gsutil -q rm ${LOCKFILE_PATH}" EXIT
+trap "echo ${CMD} removing ${LOCKFILE_PATH} ; gcloud storage rm --quiet ${LOCKFILE_PATH}" EXIT
 
 # Copy the existing CVDs from GCS to a local directory.
 # ignore errors as it implies empty db in mirror (ie first run).
 mkdir -p ./cvds
 echo "${CMD} Downloading CVD mirror from gs://${CVD_MIRROR_BUCKET}/cvds/"
-gsutil -m -q rsync -d -c -r -x cvds/log "gs://${CVD_MIRROR_BUCKET}/cvds/" ./cvds
+gcloud storage rsync "gs://${CVD_MIRROR_BUCKET}/cvds/" ./cvds --delete-unmatched-destination-objects --checksums-only --recursive --exclude=cvds/log --quiet
 
 set -o errexit
 
@@ -94,6 +94,6 @@ cat ./cvds/log/*.log
 
 # Push any updated databases back to GCS
 echo "${CMD} Updating CVD mirror at gs://${CVD_MIRROR_BUCKET}/cvds/"
-gsutil -m -q rsync -d -c -r -x '.*\.log' ./cvds "gs://${CVD_MIRROR_BUCKET}/cvds/"
+gcloud storage rsync ./cvds "gs://${CVD_MIRROR_BUCKET}/cvds/" --delete-unmatched-destination-objects --checksums-only --recursive --exclude='.*\.log' --quiet
 
 echo "${CMD} completed"


### PR DESCRIPTION
## Summary
GCP is removing `gsutil` from the default `gcloud` CLI bundle starting March 2027 (see [announcement](https://cloud.google.com/storage/docs/gsutil-transition-to-gcloud)). This migrates this repo's scripts/CI off `gsutil` onto the recommended `gcloud storage` equivalents.

Part of bcgov/entity#34311.

## Test plan
- [ ] Verify `gcloud storage` commands run successfully in this repo's actual CI/job environment (has `gcloud` CLI, correct auth/permissions)
- [ ] Confirm bucket/object operations produce the same result as the old `gsutil` calls